### PR TITLE
#4 configfileのパースロジックの追加

### DIFF
--- a/inc/ServerConfig.hpp
+++ b/inc/ServerConfig.hpp
@@ -6,7 +6,7 @@
 /*   By: hirwatan <hirwatan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 14:28:13 by hirwatan          #+#    #+#             */
-/*   Updated: 2025/06/30 14:28:17 by hirwatan         ###   ########.fr       */
+/*   Updated: 2025/06/30 17:20:44 by hirwatan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,8 +37,7 @@ private:
 public:
     ServerConfig();
     ~ServerConfig();
-    void readFile(const std::string &filePath);
-    // void init();
+
 //setter
     void setHost(const std::string &host);
     void setPort(int port);
@@ -58,4 +57,10 @@ public:
     long getClientMaxBodySize() const;
     const std::map<int, std::string> &getErrorPages() const;
     const std::vector<LocationConfig> &getLocations() const;
+
+//parse
+    static std::vector<ServerConfig> parseConfigFile(const std::string &filePath);
+    void parseServerLine(const std::string &line);
+    void parseLocationLine(const std::string &line, LocationConfig &location);
+
 };

--- a/inc/Utils.hpp
+++ b/inc/Utils.hpp
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Utils.hpp                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hirwatan <hirwatan@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/30 16:35:40 by hirwatan          #+#    #+#             */
+/*   Updated: 2025/06/30 17:11:00 by hirwatan         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#pragma once
+#include <algorithm>
+#include <cctype>
+
+struct NotSpace {
+    bool operator()(char c) const {
+        return !std::isspace(static_cast<unsigned char>(c));
+    }
+};
+
+// 前方から空白をトリムする関数
+std::string &ft_ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), NotSpace()));
+    return s;
+}
+
+// 後方から空白をトリムする関数
+std::string &ft_rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), NotSpace()).base(), s.end());
+    return s;
+}
+
+// 両端から空白をトリムする関数（新しい文字列を返すバージョン）
+std::string ft_trim(const std::string &s) {
+    std::string copy = s;
+    return ft_ltrim(ft_rtrim(copy));
+}

--- a/inc/Webserv.hpp
+++ b/inc/Webserv.hpp
@@ -6,20 +6,24 @@
 /*   By: hirwatan <hirwatan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/05 04:10:11 by teando            #+#    #+#             */
-/*   Updated: 2025/06/30 15:16:05 by hirwatan         ###   ########.fr       */
+/*   Updated: 2025/06/30 17:23:37 by hirwatan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 #include "ServerConfig.hpp"
+#include <vector>
 
 class Webserv
 {
     private:
-        ServerConfig    _serverconfig;
+        std::vector<ServerConfig> _serverconfigs;
     public:
         Webserv(const std::string &filePath);
         ~Webserv();
-        // void run();
+        void run();
+        const std::vector<ServerConfig>& getServerConfigs() const;
+        void printConfigs() const;
 };
 
+std::ostream &operator<<(std::ostream &os, const ServerConfig &config);

--- a/src/Config/ServerConfig.cpp
+++ b/src/Config/ServerConfig.cpp
@@ -6,36 +6,202 @@
 /*   By: hirwatan <hirwatan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:10:58 by hirwatan          #+#    #+#             */
-/*   Updated: 2025/06/30 15:17:59 by hirwatan         ###   ########.fr       */
+/*   Updated: 2025/06/30 17:19:30 by hirwatan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../inc/ServerConfig.hpp"
+#include "../../inc/Utils.hpp"
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <cstdlib>
 
-ServerConfig::ServerConfig()
-	: _host("0.0.0.0"), _port(8080), _server_name("localhost"),
-	  _client_max_body_size(1048576) {}
+ServerConfig::ServerConfig(){}
 
-ServerConfig::~ServerConfig() {}
+ServerConfig::~ServerConfig(){}
 
-void ServerConfig::readFile(const std::string &filePath) {
-	std::ifstream ifs(filePath.c_str());
-	if (!ifs.is_open()) {
-		std::string error_message = "エラー: ファイルを開けませんでした -> ";
-		error_message += filePath;
-		throw std::runtime_error(error_message);
-	}
-	//パースなどしていく 今は中身を出力しているだけ
-	// std::stringstream buffer;
-	// buffer << ifs.rdbuf();
-	// std::string fileContent = buffer.str();
-	// std::cout << "ファイルの内容\n" << fileContent << std::endl;
-	ifs.close();
+std::vector<ServerConfig> ServerConfig::parseConfigFile(const std::string &filePath) {
+    std::ifstream ifs(filePath.c_str());
+    if (!ifs.is_open()) {
+        std::string error_message = "エラー: ファイルを開けませんでした -> ";
+        error_message += filePath;
+        throw std::runtime_error(error_message);
+    }
+    
+    std::vector<ServerConfig> servers;
+    std::string line;
+    bool inServerBlock = false;
+    bool inLocationBlock = false;
+    ServerConfig currentServer;
+    LocationConfig currentLocation;
+
+    while (std::getline(ifs, line)) {
+        // コメントと空白スキップ
+        if (line.empty() || line[0] == '#') continue;
+        
+        line = ft_trim(line);
+        if (line.empty()) continue;
+
+        // server {が存在するかどうか
+        if(line.find("server {") != std::string::npos) {
+            if (inServerBlock) {
+                // 前のサーバーを保存
+                servers.push_back(currentServer);
+            }
+            currentServer = ServerConfig();  // 新しいサーバー設定を開始
+            inServerBlock = true;
+            inLocationBlock = false;
+            continue;
+        }
+
+        if (inServerBlock && line == "}") {
+            if (inLocationBlock) {
+                currentServer.addLocation(currentLocation);
+                currentLocation = LocationConfig();
+                inLocationBlock = false;
+            } else {
+                // サーバーブロックの終了
+                servers.push_back(currentServer);
+                inServerBlock = false;
+            }
+            continue;
+        }
+        
+        if (inServerBlock) {
+            if (line.find("location ") != std::string::npos) {
+                if (inLocationBlock) {
+                    currentServer.addLocation(currentLocation);
+                }
+                currentLocation = LocationConfig();
+                inLocationBlock = true;
+                
+                // location パスを抽出
+                size_t start = line.find("location ") + 9;
+                size_t end = line.find(" {");
+                if (end != std::string::npos) {
+                    std::string path = line.substr(start, end - start);
+                    path = ft_trim(path);
+                    currentLocation.setPath(path);
+                }
+                continue;
+            }
+            
+            if (inLocationBlock) {
+                currentServer.parseLocationLine(line, currentLocation);
+            } else {
+                currentServer.parseServerLine(line);
+            }
+        }
+    }
+    
+    // 最後のサーバーまたはロケーションを追加
+    if (inLocationBlock) {
+        currentServer.addLocation(currentLocation);
+    }
+    if (inServerBlock) {
+        servers.push_back(currentServer);
+    }
+    
+    ifs.close();
+    return servers;
 }
+
+void ServerConfig::parseServerLine(const std::string &line) {
+    std::istringstream iss(line);
+    std::string directive;
+    iss >> directive;
+    
+    if (directive == "listen") {
+        std::string listen_value;
+        iss >> listen_value;
+        
+        // ":"で分割してホストとポートを取得
+        size_t colon_pos = listen_value.find(':');
+        if (colon_pos != std::string::npos) {
+            _host = listen_value.substr(0, colon_pos);
+            _port = atoi(listen_value.substr(colon_pos + 1).c_str());
+        } else {
+            _port = atoi(listen_value.c_str());
+        }
+    }
+    else if (directive == "server_name") {
+        std::string server_name;
+        iss >> server_name;
+        _server_name = server_name;
+    }
+    else if (directive == "client_max_body_size") {
+        std::string size_str;
+        iss >> size_str;
+        
+        if (!size_str.empty()) {
+            char last_char = size_str[size_str.length() - 1];
+            if (last_char == 'm' || last_char == 'M') {
+                size_str = size_str.substr(0, size_str.length() - 1);
+                _client_max_body_size = atol(size_str.c_str()) * 1024 * 1024;
+            } else if (last_char == 'k' || last_char == 'K') {
+                size_str = size_str.substr(0, size_str.length() - 1);
+                _client_max_body_size = atol(size_str.c_str()) * 1024;
+            } else {
+                _client_max_body_size = atol(size_str.c_str());
+            }
+        }
+    }
+    else if (directive == "error_page") {
+        int status_code;
+        std::string path;
+        iss >> status_code >> path;
+        addErrorPage(status_code, path);
+    }
+}
+
+void ServerConfig::parseLocationLine(const std::string &line, LocationConfig &location) {
+    std::istringstream iss(line);
+    std::string directive;
+    iss >> directive;
+    
+    if (directive == "root") {
+        std::string root;
+        iss >> root;
+        location.setRoot(root);
+    }
+    else if (directive == "index") {
+        std::vector<std::string> indices;
+        std::string index;
+        while (iss >> index) {
+            indices.push_back(index);
+        }
+        location.setIndex(indices);
+    }
+    else if (directive == "autoindex") {
+        std::string value;
+        iss >> value;
+        location.setAutoindex(value == "on");
+    }
+    else if (directive == "methods") {
+        std::vector<std::string> methods;
+        std::string method;
+        while (iss >> method) {
+            methods.push_back(method);
+        }
+        location.setMethods(methods);
+    }
+    else if (directive == "cgi") {
+        std::string ext, bin;
+        iss >> ext >> bin;
+        CgiConfig cgi_config;
+        cgi_config.ext = ext;
+        cgi_config.bin = bin;
+        location.addCgi(cgi_config);
+    }
+    else if (directive == "redirect") {
+        std::string redirect_url;
+        iss >> redirect_url;
+        location.setRedirect(redirect_url);
+    }
+}
+
 
 //setter
 void ServerConfig::setHost(const std::string &host) { _host = host; }

--- a/src/Server/Webserv.cpp
+++ b/src/Server/Webserv.cpp
@@ -6,16 +6,64 @@
 /*   By: hirwatan <hirwatan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:10:53 by hirwatan          #+#    #+#             */
-/*   Updated: 2025/06/30 15:17:42 by hirwatan         ###   ########.fr       */
+/*   Updated: 2025/06/30 17:22:58 by hirwatan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/Webserv.hpp"
 #include <iostream>
 
-Webserv ::Webserv(const std::string &filePath) {
-	_serverconfig.readFile(filePath);
+Webserv::Webserv(const std::string &filePath) {
+    _serverconfigs = ServerConfig::parseConfigFile(filePath);
+    printConfigs();
 }
 
 Webserv::~Webserv() {}
-// void Webserv::run(){}
+
+const std::vector<ServerConfig>& Webserv::getServerConfigs() const {
+    return _serverconfigs;
+}
+
+void Webserv::printConfigs() const {
+    std::cout << "=== Loaded " << _serverconfigs.size() << " server configurations ===" << std::endl;
+    for (size_t i = 0; i < _serverconfigs.size(); ++i) {
+        std::cout << "--- Server " << (i + 1) << " ---" << std::endl;
+        std::cout << _serverconfigs[i] << std::endl;
+    }
+}
+
+void Webserv::run() {
+    std::cout << "Starting " << _serverconfigs.size() << " servers..." << std::endl;
+}
+//debug
+std::ostream &operator<<(std::ostream &os, const ServerConfig &config)
+{
+    os << "=== Server Configuration ===" << std::endl;
+    os << "Host: " << config.getHost() << std::endl;
+    os << "Port: " << config.getPort() << std::endl;
+    os << "Server Name: " << config.getServerName() << std::endl;
+    os << "Client Max Body Size: " << config.getClientMaxBodySize() << std::endl;
+    
+    // Error Pages
+    const std::map<int, std::string> &errorPages = config.getErrorPages();
+    if (!errorPages.empty()) {
+        os << "Error Pages:" << std::endl;
+        for (std::map<int, std::string>::const_iterator it = errorPages.begin(); 
+             it != errorPages.end(); ++it) {
+            os << "  " << it->first << ": " << it->second << std::endl;
+        }
+    }
+    
+    // Locations
+    const std::vector<LocationConfig> &locations = config.getLocations();
+    if (!locations.empty()) {
+        os << "Locations:" << std::endl;
+        for (size_t i = 0; i < locations.size(); ++i) {
+            os << "  Path: " << locations[i].getPath() << std::endl;
+            os << "  Root: " << locations[i].getRoot() << std::endl;
+            os << "  Autoindex: " << (locations[i].getAutoindex() ? "on" : "off") << std::endl;
+        }
+    }
+    
+    return os;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: hirwatan <hirwatan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:10:43 by hirwatan          #+#    #+#             */
-/*   Updated: 2025/06/30 15:16:23 by hirwatan         ###   ########.fr       */
+/*   Updated: 2025/06/30 17:22:15 by hirwatan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
 			throw std::invalid_argument("usage: ./webserv <config.file>");
 		}
 		Webserv webserv(argv[1]);
-		// webserv.run();
+		webserv.run();
 	} catch (const std::exception &e) {
 		std::cerr << e.what() << std::endl;
 	}


### PR DESCRIPTION
### add configファイルをperseする際に必要なヘルパー関数の再実装 trim rtrim ltrim
・ファイルからgetlineした時に余分な空白が存在してしまうため、それを取り除く
関数の再実装

---
### modified severconfigは一個ではなく複数個存在するため　vectorに変更、デバックログとgetterの追加
・configfileの中身で、別のポートが開かれる場合があったため vectorに変更した
ここにはないが上書きする仕様になっていた

---
### modified readFileではなくparseConfigFileに変更　それに伴いServer Locatoionのpearse関…
・シンプルにわかりにくい名前だったので修正　要素要素でparseするヘッダーの追加

---
### add pearseを追加　各要素の名前から適したところにsetしている、※エラーチェックは未対応

・わりぃ！　リサーチ不足でどこまでがエラーかを断定出来てない！

ファイル読み込み開始
    ↓
各行をループ処理
    ↓
コメント・空行をスキップ
    ↓
行の種類を判定
    ├─ "server {" → 新しいサーバーブロック開始
    ├─ "location XXX {" → 新しいロケーションブロック開始  
    ├─ "}" → 現在のブロック終了
    └─ その他 → 設定行として解析