### PR TITLE
Feat: Name-based VirtualHost の導入と listen 定義・リクエスト制限の整理

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,7 +3,7 @@ servers:
     listens:
       - listen:
           interface: 127.0.0.1
-          port: 8081
+          port: 8080
 
     access_logs:
       - access_log:
@@ -26,7 +26,8 @@ servers:
   - server:
       listens:
         - listen:
-            interface: 0.0.0.0
+            host: localhost
+            interface: 127.0.0.1
             port: 8080
 
       maxRequestBodySize: 6291456

--- a/src/Config/Config.hpp
+++ b/src/Config/Config.hpp
@@ -35,6 +35,7 @@ struct Performance {
 };
 
 struct Listen {
+	std::string host;
 	std::string interface;
 	int port;
 };

--- a/src/Config/ConfigParser.cpp
+++ b/src/Config/ConfigParser.cpp
@@ -7,8 +7,8 @@
 #include "ConfigLocationParser.hpp"
 #include "ConfigLogParser.hpp"
 
-#include <ctime>
 #include <cstring>
+#include <ctime>
 #include <limits>
 #include <netdb.h>
 #include <set>
@@ -73,6 +73,7 @@ static std::set< std::string > createValidServerKeys() {
 
 static std::set< std::string > createValidListenKeys() {
 	std::set< std::string > keys;
+	keys.insert("host");
 	keys.insert("interface");
 	keys.insert("port");
 	return keys;
@@ -177,12 +178,16 @@ void ConfigParser::parseListens(const Node *node) const {
 			throw std::runtime_error(
 				"Config error: missing 'listen' key in listen item");
 		}
-
-		const char *validKeysArr[] = {"interface", "port"};
-		std::set< std::string > validKeys(validKeysArr, validKeysArr + 2);
-		validateKeys(l_node, validKeys, "listen block");
+		validateKeys(l_node, VALID_LISTEN_KEYS, "listen block");
 
 		Listen l;
+		const Node *hostNode = l_node->getMapNode("host");
+		if (!hostNode) {
+			l.host = "";
+		} else {
+			l.host = hostNode->getValue();
+		}
+
 		const Node *interfaceNode = l_node->getMapNode("interface");
 		if (!interfaceNode) {
 			l.interface = "0.0.0.0";
@@ -209,8 +214,7 @@ void ConfigParser::parseListens(const Node *node) const {
 		hints.ai_socktype = SOCK_STREAM;
 		hints.ai_flags = AI_NUMERICHOST;
 		addrinfo *res = NULL;
-		const int ret =
-			getaddrinfo(l.interface.c_str(), NULL, &hints, &res);
+		const int ret = getaddrinfo(l.interface.c_str(), NULL, &hints, &res);
 		if (ret != 0) {
 			throw std::runtime_error(
 				"Config error: invalid listen interface '" + l.interface + "'");
@@ -263,15 +267,12 @@ void ConfigParser::parseServer(const Node *serverNode) const {
 	if (const Node *n = serverNode->getMapNode("root"))
 		_builder->setServerDefaultRoot(n->getValue());
 	if (const Node *n = serverNode->getMapNode("allowedMethods")) {
-		const char *validMethodsArr[] = {"GET", "POST", "HEAD", "DELETE"};
-		std::set< std::string > validMethods(validMethodsArr,
-											 validMethodsArr + 4);
 		std::set< std::string > methodsSet;
 		const std::vector< Node * > &methods = n->getSeq();
 		for (std::vector< Node * >::const_iterator m_it = methods.begin();
 			 m_it != methods.end(); ++m_it) {
 			std::string method = (*m_it)->getValue();
-			if (validMethods.find(method) == validMethods.end()) {
+			if (VALID_ALLOWED_METHODS.find(method) == VALID_ALLOWED_METHODS.end()) {
 				throw std::runtime_error("Config error: invalid HTTP method '" +
 										 method + "' in server block");
 			}

--- a/src/Middleware/SubPipeline/RequestLimits/RequestLimitsMiddleware.cpp
+++ b/src/Middleware/SubPipeline/RequestLimits/RequestLimitsMiddleware.cpp
@@ -20,7 +20,7 @@ void RequestLimitsMiddleware::handle(PipelineContext &ctx,
 
 	// Check: Request Header Size
 	const size_t headerBytes = ctx.parser.getLastHeaderBytes();
-	if (&c != NULL && c.getMaxRequestHeaderSize() < headerBytes) {
+	if (c.getMaxRequestHeaderSize() < headerBytes) {
 		ctx.setError(HttpStatus::REQUEST_HEADER_FIELDS_TOO_LARGE);
 		if (proc) {
 			ErrorHandlerMiddleware errorHandler;

--- a/src/Middleware/SubPipeline/RequestLimits/RequestLimitsMiddleware.cpp
+++ b/src/Middleware/SubPipeline/RequestLimits/RequestLimitsMiddleware.cpp
@@ -15,11 +15,22 @@ void RequestLimitsMiddleware::handle(PipelineContext &ctx,
 		return;
 	}
 
-	const Config &config = *ctx.conf;
-	const Location &loc = config.getLocation(ctx.req.getPath());
+	const Config &c = *ctx.conf;
+	const Location &loc = c.getLocation(ctx.req.getPath());
+
+	// Check: Request Header Size
+	const size_t headerBytes = ctx.parser.getLastHeaderBytes();
+	if (&c != NULL && c.getMaxRequestHeaderSize() < headerBytes) {
+		ctx.setError(HttpStatus::REQUEST_HEADER_FIELDS_TOO_LARGE);
+		if (proc) {
+			ErrorHandlerMiddleware errorHandler;
+			errorHandler.handle(ctx, proc);
+		}
+		return;
+	}
 
 	// Set: Request Body Size limit
-	size_t maxBodySize = config.getMaxRequestBodySize();
+	size_t maxBodySize = c.getMaxRequestBodySize();
 	if (loc.hasMaxRequestBodySize) {
 		maxBodySize = loc.maxRequestBodySize;
 	}

--- a/src/Middleware/VHost/VHostSelectMiddleware.cpp
+++ b/src/Middleware/VHost/VHostSelectMiddleware.cpp
@@ -22,6 +22,7 @@ void VHostSelectMiddleware::handle(PipelineContext &ctx,
 
 	// TODO: ホストヘッダーに基づく選択はまだ実装されていない
 	// ここに Host ヘッダーを解析して適切な vhost を選択するロジックを実装する
+	std::string vHostDomain = ctx.req.getHeader("Host");
 
 	ctx.setConfig(ctx.ownerClient.getConfig());
 

--- a/src/Middleware/VHost/VHostSelectMiddleware.cpp
+++ b/src/Middleware/VHost/VHostSelectMiddleware.cpp
@@ -1,6 +1,8 @@
 #include "VHostSelectMiddleware.hpp"
 #include "../../Http/Core/HttpStatus.hpp"
 #include "../../Server/Client/Client.hpp"
+#include "../../Server/Server.hpp"
+#include "../../Server/VHost/VHostResolver.hpp"
 #include "../SubPipeline/ErrorHandler/ErrorHandlerMiddleware.hpp"
 
 VHostSelectMiddleware::VHostSelectMiddleware() {}
@@ -20,26 +22,28 @@ void VHostSelectMiddleware::handle(PipelineContext &ctx,
 		return;
 	}
 
-	// TODO: ホストヘッダーに基づく選択はまだ実装されていない
-	// ここに Host ヘッダーを解析して適切な vhost を選択するロジックを実装する
-	std::string vHostDomain = ctx.req.getHeader("Host");
-
-	ctx.setConfig(ctx.ownerClient.getConfig());
+	const std::string hostHeader = ctx.req.getHeader("Host");
+	VirtualHost *selected = VHostResolver::find(
+		ctx.ownerClient.getServer().getVhosts(),
+		ctx.ownerClient.getListenKey(), hostHeader);
+	if (selected != NULL) {
+		const Config &activeConfig = ctx.ownerClient.getConfig();
+		if (&activeConfig != &selected->config) {
+			ctx.ownerClient.setActiveVhost(*selected);
+			ctx.setConfig(selected->config);
+			if (proc) {
+				ctx.ownerClient.getMainProcessor().handle(ctx);
+			}
+			return;
+		}
+		ctx.setConfig(selected->config);
+	} else {
+		ctx.setConfig(ctx.ownerClient.getConfig());
+	}
 
 	// エラーチェック: Configが正しくセットされているか
 	if (ctx.conf == NULL) {
 		ctx.setError(HttpStatus::INTERNAL_SERVER_ERROR);
-		if (proc) {
-			ErrorHandlerMiddleware errorHandler;
-			errorHandler.handle(ctx, proc);
-		}
-		return;
-	}
-
-	/// vhost指定のリクエストヘッダサイズの検証とエラーハンドリング （ホスト確定後のため）
-	const size_t headerBytes = ctx.parser.getLastHeaderBytes();
-	if (ctx.conf != NULL && ctx.conf->getMaxRequestHeaderSize() < headerBytes) {
-		ctx.setError(HttpStatus::REQUEST_HEADER_FIELDS_TOO_LARGE);
 		if (proc) {
 			ErrorHandlerMiddleware errorHandler;
 			errorHandler.handle(ctx, proc);

--- a/src/Server/Bootstrap/ServerBootstrap.cpp
+++ b/src/Server/Bootstrap/ServerBootstrap.cpp
@@ -1,4 +1,5 @@
 #include "ServerBootstrap.hpp"
+#include "../../Lib/StringOps/StringOps.hpp"
 #include <algorithm>
 #include <map>
 #include <set>
@@ -10,6 +11,12 @@ std::string listenToString(const Listen &listen) {
 	std::ostringstream oss;
 	oss << listen.interface << ":" << listen.port;
 	return oss.str();
+}
+
+std::string normalizeListenHost(const std::string &host) {
+	std::string normalized = StringOps::trim(host);
+	StringOps::toLower(normalized);
+	return normalized;
 }
 
 size_t resolveCgiMaxWorkers(const std::vector< Config > &configs) {
@@ -63,7 +70,8 @@ resolveListenHeaderMax(const std::vector< Config > &configs) {
 }
 
 void validateListenCompatibility(const std::vector< Config > &configs) {
-	std::set< std::pair< std::string, int > > seen;
+	std::map< std::pair< std::string, int >, std::set< std::string > >
+		hostsByListen;
 	std::set< int > wildcardPorts;
 	std::set< int > specificPorts;
 
@@ -75,13 +83,16 @@ void validateListenCompatibility(const std::vector< Config > &configs) {
 		}
 		for (size_t j = 0; j < listens.size(); ++j) {
 			const Listen &listen = listens[j];
-			// Host name ロジックを追加する場合は、この処理を変更する
 			const std::pair< std::string, int > key(listen.interface,
 													listen.port);
-			if (seen.count(key)) {
-				throw std::runtime_error("Config error: duplicate listen " +
-										 listenToString(listen));
+			const std::string hostKey = normalizeListenHost(listen.host);
+			std::set< std::string > &seenHosts = hostsByListen[key];
+			if (seenHosts.count(hostKey)) {
+				throw std::runtime_error(
+					"Config error: duplicate listen host " +
+					listenToString(listen));
 			}
+			seenHosts.insert(hostKey);
 			const bool isWildcard = (listen.interface == "0.0.0.0");
 			if (isWildcard) {
 				if (specificPorts.count(listen.port)) {
@@ -103,7 +114,6 @@ void validateListenCompatibility(const std::vector< Config > &configs) {
 				}
 				specificPorts.insert(listen.port);
 			}
-			seen.insert(key);
 		}
 	}
 }

--- a/src/Server/Client/Client.cpp
+++ b/src/Server/Client/Client.cpp
@@ -20,13 +20,15 @@
 #include <unistd.h>
 
 // clang-format off
-Client::Client(const int fd, const sockaddr_in &addr, const int listenPort,
-			   VirtualHost &activeVhost, const size_t maxHeaderBytes,
+Client::Client(const int fd, const sockaddr_in &addr,
+			   const ListenKey &listenKey,
+			   VirtualHost &activeVhost,
+			   const size_t maxHeaderBytes,
 			   Server &server, EventManager &eventManager)
 	: _server(server),
 	  _activeVhost(&activeVhost),
 	  _fd(fd),
-	  _listenPort(listenPort),
+	  _listenKey(listenKey),
 	  _socket(activeVhost.config, fd, addr),
 	  _context(activeVhost.config, maxHeaderBytes, *this,
 			   server.getCgiManager()),
@@ -50,7 +52,7 @@ void Client::setActiveVhost(VirtualHost &vhost) { _activeVhost = &vhost; }
 
 int Client::getFd() const { return _fd; }
 int Client::getPort() const { return _port; }
-int Client::getListenPort() const { return _listenPort; }
+const ListenKey &Client::getListenKey() const { return _listenKey; }
 const std::string &Client::getIp() const { return _ip; }
 
 Socket &Client::getSocket() { return _socket; }

--- a/src/Server/Client/Client.hpp
+++ b/src/Server/Client/Client.hpp
@@ -3,6 +3,7 @@
 #include "../../Lib/Timeout/ITimeoutable.hpp"
 #include "../../Middleware/Core/PipelineContext.hpp"
 #include "../../Socket/Socket.hpp"
+#include "../Listen/ListenKey.hpp"
 #include "../VHost/VirtualHost.hpp"
 #include "EventManager.hpp"
 #include "HttpConnection.hpp"
@@ -16,7 +17,7 @@ class EventManager;
 
 class Client : public ITimeoutable, public HttpConnectionEventHandler {
 public:
-	Client(int fd, const sockaddr_in &addr, int listenPort,
+	Client(int fd, const sockaddr_in &addr, const ListenKey &listenKey,
 		   VirtualHost &activeVhost, size_t maxHeaderBytes, Server &server,
 		   EventManager &eventManager);
 	~Client();
@@ -29,7 +30,7 @@ public:
 
 	int getFd() const;
 	int getPort() const;
-	int getListenPort() const;
+	const ListenKey &getListenKey() const;
 	const std::string &getIp() const;
 
 	Socket &getSocket();
@@ -60,7 +61,7 @@ private:
 	VirtualHost *_activeVhost;
 	int _fd;
 	int _port;
-	int _listenPort;
+	ListenKey _listenKey;
 	std::string _ip;
 	Socket _socket;
 	PipelineContext _context;

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -6,8 +6,8 @@
 #include "Bootstrap/ServerBootstrap.hpp"
 #include "Client/Events/ReadEvent.hpp"
 #include "Client/Events/WriteEvent.hpp"
-#include "Logging/Logging.hpp"
 #include "Listen/ListenKey.hpp"
+#include "Logging/Logging.hpp"
 
 #include <algorithm>
 #include <cerrno>
@@ -72,6 +72,8 @@ Server::~Server() {
 TimeoutManager &Server::getTimeoutManager() { return _timeoutManager; }
 SocketsManager &Server::getSocketsManager() { return _socketsManager; }
 CgiManager &Server::getCgiManager() { return _cgiManager; }
+std::vector< VirtualHost > &Server::getVhosts() { return _vhosts; }
+const std::vector< VirtualHost > &Server::getVhosts() const { return _vhosts; }
 
 
 void Server::run() {
@@ -109,12 +111,11 @@ void Server::handleNewConnection(const int listenFd) {
 		return;
 	}
 	if (accepted.fd < 0) {
-        // EAGAINやEWOULDBLOCKはノンブロッキングソケットで一時的な正常状態。
-        // それ以外のerrnoは異常なのでログ出力する。
+		// EAGAINやEWOULDBLOCKはノンブロッキングソケットで一時的な正常状態。
+		// それ以外のerrnoは異常なのでログ出力する。
 		if (errno != EAGAIN && errno != EWOULDBLOCK) {
-			LOG(ERROR)
-				<< "accept() failed or client socket setup failed: "
-				<< strerror(errno);
+			LOG(ERROR) << "accept() failed or client socket setup failed: "
+					   << strerror(errno);
 		}
 		return;
 	}
@@ -138,10 +139,12 @@ void Server::handleNewConnection(const int listenFd) {
 	try {
 		VirtualHost *vhost = &_vhosts[accepted.defaultVhostIndex];
 
-		// Host name に基づく仮想ホストの切り替えは Middleware 側で行うため、多重listen対応のため
+		// Host name に基づく仮想ホストの切り替えは Middleware
+		// 側で行うため、多重listen対応のため
 		size_t maxHeaderBytes = vhost->config.getMaxRequestHeaderSize();
 		// 接続 listen の デフォルト key
-		const std::string listenKey = ListenKey::listenKeyToString(accepted.key);
+		const std::string listenKey =
+			ListenKey::listenKeyToString(accepted.key);
 		// 同 listen 単位の max があれば上書きする
 		std::map< std::string, size_t >::const_iterator maxIt =
 			_listenHeaderMax.find(listenKey);
@@ -149,8 +152,8 @@ void Server::handleNewConnection(const int listenFd) {
 			maxHeaderBytes = maxIt->second;
 		}
 
-		client = new Client(accepted.fd, accepted.addr, accepted.key.port,
-							*vhost, maxHeaderBytes, *this, _eventManager);
+		client = new Client(accepted.fd, accepted.addr, accepted.key, *vhost,
+							maxHeaderBytes, *this, _eventManager);
 
 		_socketsManager.registerSocket(accepted.fd, EPOLLIN);
 		_eventManager.initFd(*client);
@@ -179,7 +182,8 @@ void Server::handleNewConnection(const int listenFd) {
 		try {
 			_eventManager.forgetFd(accepted.fd);
 		} catch (...) {
-			// 例外処理中の二次例外で元の例外を潰さない。例外漏れによる terminate を回避
+			// 例外処理中の二次例外で元の例外を潰さない。例外漏れによる
+			// terminate を回避
 		}
 		try {
 			_socketsManager.unregisterSocket(accepted.fd);

--- a/src/Server/Server.hpp
+++ b/src/Server/Server.hpp
@@ -28,6 +28,8 @@ public:
 	TimeoutManager &getTimeoutManager();
 	SocketsManager &getSocketsManager();
 	CgiManager &getCgiManager();
+	std::vector< VirtualHost > &getVhosts();
+	const std::vector< VirtualHost > &getVhosts() const;
 
 	void handleNewConnection(int listenFd);
 

--- a/src/Server/VHost/VHostResolver.cpp
+++ b/src/Server/VHost/VHostResolver.cpp
@@ -40,12 +40,12 @@ VirtualHost *VHostResolver::find(std::vector< VirtualHost > &vhosts,
 				listen.port != listenKey.port) {
 				continue;
 			}
-			if (defaultVhost == NULL) {
+			const std::string listenHost =
+				extractHostForMatch(listen.host);
+			if (defaultVhost == NULL || listenHost.empty()) {
 				defaultVhost = &vhost;
 			}
 			if (!headerHost.empty()) {
-				const std::string listenHost =
-					extractHostForMatch(listen.host);
 				if (!listenHost.empty() && listenHost == headerHost) {
 					return &vhost;
 				}

--- a/src/Server/VHost/VHostResolver.cpp
+++ b/src/Server/VHost/VHostResolver.cpp
@@ -26,6 +26,9 @@ VirtualHost *VHostResolver::find(std::vector< VirtualHost > &vhosts,
 								 const ListenKey &listenKey,
 								 const std::string &hostHeader) {
 	VirtualHost *defaultVhost = NULL;
+	if (vhosts.empty()) {
+		return NULL;
+	}
 	const std::string headerHost = extractHostForMatch(hostHeader);
 
 	for (size_t i = 0; i < vhosts.size(); ++i) {

--- a/src/Server/VHost/VHostResolver.cpp
+++ b/src/Server/VHost/VHostResolver.cpp
@@ -1,0 +1,63 @@
+#include "VHostResolver.hpp"
+#include "../../Lib/StringOps/StringOps.hpp"
+
+namespace {
+
+std::string extractHostForMatch(const std::string &value) {
+	std::string trimmed = StringOps::trim(value);
+	if (trimmed.empty()) {
+		return std::string();
+	}
+	std::string host;
+	if (trimmed[0] == '[') {
+		size_t end = trimmed.find(']');
+		if (end != std::string::npos && end > 1) {
+			host = trimmed.substr(1, end - 1);
+		} else {
+			host = trimmed;
+		}
+	} else {
+		size_t colon = trimmed.find(':');
+		if (colon != std::string::npos &&
+			trimmed.find(':', colon + 1) == std::string::npos) {
+			host = trimmed.substr(0, colon);
+		} else {
+			host = trimmed;
+		}
+	}
+	StringOps::trim(host);
+	StringOps::toLower(host);
+	return host;
+}
+
+} // namespace
+
+VirtualHost *VHostResolver::find(std::vector< VirtualHost > &vhosts,
+								 const ListenKey &listenKey,
+								 const std::string &hostHeader) {
+	VirtualHost *defaultVhost = NULL;
+	const std::string headerHost = extractHostForMatch(hostHeader);
+
+	for (size_t i = 0; i < vhosts.size(); ++i) {
+		VirtualHost &vhost = vhosts[i];
+		const std::vector< Listen > &listens = vhost.config.getListens();
+		for (size_t j = 0; j < listens.size(); ++j) {
+			const Listen &listen = listens[j];
+			if (listen.interface != listenKey.interface ||
+				listen.port != listenKey.port) {
+				continue;
+			}
+			if (defaultVhost == NULL) {
+				defaultVhost = &vhost;
+			}
+			if (!headerHost.empty()) {
+				const std::string listenHost =
+					extractHostForMatch(listen.host);
+				if (!listenHost.empty() && listenHost == headerHost) {
+					return &vhost;
+				}
+			}
+		}
+	}
+	return defaultVhost;
+}

--- a/src/Server/VHost/VHostResolver.cpp
+++ b/src/Server/VHost/VHostResolver.cpp
@@ -9,21 +9,11 @@ std::string extractHostForMatch(const std::string &value) {
 		return std::string();
 	}
 	std::string host;
-	if (trimmed[0] == '[') {
-		size_t end = trimmed.find(']');
-		if (end != std::string::npos && end > 1) {
-			host = trimmed.substr(1, end - 1);
-		} else {
-			host = trimmed;
-		}
+	size_t colon = trimmed.find(':');
+	if (colon != std::string::npos) {
+		host = trimmed.substr(0, colon);
 	} else {
-		size_t colon = trimmed.find(':');
-		if (colon != std::string::npos &&
-			trimmed.find(':', colon + 1) == std::string::npos) {
-			host = trimmed.substr(0, colon);
-		} else {
-			host = trimmed;
-		}
+		host = trimmed;
 	}
 	StringOps::trim(host);
 	StringOps::toLower(host);

--- a/src/Server/VHost/VHostResolver.hpp
+++ b/src/Server/VHost/VHostResolver.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../Listen/ListenKey.hpp"
+#include "VirtualHost.hpp"
+#include <string>
+#include <vector>
+
+class VHostResolver {
+public:
+	static VirtualHost *find(std::vector< VirtualHost > &vhosts,
+							 const ListenKey &listenKey,
+							 const std::string &hostHeader);
+
+private:
+	VHostResolver();
+	~VHostResolver();
+	VHostResolver(const VHostResolver &);
+	VHostResolver &operator=(const VHostResolver &);
+};

--- a/test/confs/invalid/server/listens/invalid_duplicate_listen_host.yaml
+++ b/test/confs/invalid/server/listens/invalid_duplicate_listen_host.yaml
@@ -1,0 +1,13 @@
+servers:
+  - server:
+      listens:
+        - listen:
+            interface: 127.0.0.1
+            port: 8080
+            host: example.com
+  - server:
+      listens:
+        - listen:
+            interface: 127.0.0.1
+            port: 8080
+            host: example.com

--- a/test/test_suite/test_00_startup/test_valid_startup.py
+++ b/test/test_suite/test_00_startup/test_valid_startup.py
@@ -1,6 +1,7 @@
 """
 サーバーの正常起動テスト
 """
+import os
 import socket
 import subprocess
 import tempfile
@@ -174,6 +175,85 @@ class TestValidStartup:
                 url = f"http://{DEFAULT_HOST}:{listen_ports[1]}/"
                 response = requests.get(url, timeout=2)
                 assert response.status_code == 200
+            finally:
+                if proc.poll() is None:
+                    proc.terminate()
+                    proc.wait()
+
+    def test_listen_host_allows_same_ip_port(self, webserv_bin):
+        port = _find_free_port()
+        with tempfile.TemporaryDirectory(prefix="vhost_host_listen_") as temp_dir:
+            root_a = os.path.join(temp_dir, "root_a")
+            root_b = os.path.join(temp_dir, "root_b")
+            os.makedirs(root_a)
+            os.makedirs(root_b)
+
+            index_a = os.path.join(root_a, "index.html")
+            index_b = os.path.join(root_b, "index.html")
+            with open(index_a, "w") as f:
+                f.write("host-a")
+            with open(index_b, "w") as f:
+                f.write("host-b")
+
+            config_path = Path(temp_dir) / "vhost_listen_host.yaml"
+            config_text = f"""servers:
+  - server:
+      listens:
+        - listen:
+            interface: {DEFAULT_HOST}
+            port: {port}
+            host: alpha.example
+      locations:
+        - location:
+            path: /
+            root: {root_a}
+            allowedMethods:
+              - GET
+  - server:
+      listens:
+        - listen:
+            interface: {DEFAULT_HOST}
+            port: {port}
+            host: beta.example
+      locations:
+        - location:
+            path: /
+            root: {root_b}
+            allowedMethods:
+              - GET
+"""
+            config_path.write_text(config_text)
+
+            proc = subprocess.Popen(
+                [webserv_bin, str(config_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                if not _wait_for_port(DEFAULT_HOST, port):
+                    stdout, stderr = proc.communicate(timeout=1)
+                    pytest.fail(
+                        "Server did not listen on the port.\n"
+                        f"stdout:\n{stdout}\n"
+                        f"stderr:\n{stderr}\n"
+                    )
+
+                resp_a = requests.get(
+                    f"http://{DEFAULT_HOST}:{port}/",
+                    headers={"Host": "alpha.example"},
+                    timeout=2,
+                )
+                resp_b = requests.get(
+                    f"http://{DEFAULT_HOST}:{port}/",
+                    headers={"Host": "beta.example"},
+                    timeout=2,
+                )
+                assert resp_a.status_code == 200
+                assert resp_b.status_code == 200
+                assert "host-a" in resp_a.text
+                assert "host-b" in resp_b.text
+                assert resp_a.text != resp_b.text
             finally:
                 if proc.poll() is None:
                     proc.terminate()

--- a/test/test_suite/test_70_virtualhost/test_ip_port_routing.py
+++ b/test/test_suite/test_70_virtualhost/test_ip_port_routing.py
@@ -157,3 +157,106 @@ def test_ip_port_virtualhost_routing(webserv_bin):
                         proc.wait(timeout=3)
                     except subprocess.TimeoutExpired:
                         proc.kill()
+
+
+@pytest.mark.integration
+def test_host_virtualhost_routing_same_ip_port(webserv_bin):
+    port = find_free_port()
+
+    host_a_contents = "Host A response"
+    host_b_contents = "Host B response"
+
+    with tempfile.TemporaryDirectory(prefix="vhost_host_test_") as temp_dir:
+        root_a = os.path.join(temp_dir, "root_a")
+        root_b = os.path.join(temp_dir, "root_b")
+        os.makedirs(root_a)
+        os.makedirs(root_b)
+
+        index_a = os.path.join(root_a, "index.html")
+        index_b = os.path.join(root_b, "index.html")
+        with open(index_a, "w") as f:
+            f.write(host_a_contents)
+        with open(index_b, "w") as f:
+            f.write(host_b_contents)
+
+        config_path = os.path.join(temp_dir, "vhost_host.yaml")
+        config_text = f"""servers:
+  - server:
+      listens:
+        - listen:
+            interface: {DEFAULT_HOST}
+            port: {port}
+            host: alpha.example
+      locations:
+        - location:
+            path: /
+            root: {root_a}
+            index: index.html
+            autoindex: false
+            allowedMethods:
+              - GET
+  - server:
+      listens:
+        - listen:
+            interface: {DEFAULT_HOST}
+            port: {port}
+            host: beta.example
+      locations:
+        - location:
+            path: /
+            root: {root_b}
+            index: index.html
+            autoindex: false
+            allowedMethods:
+              - GET
+"""
+        with open(config_path, "w") as f:
+            f.write(config_text)
+
+        proc = subprocess.Popen(
+            [webserv_bin, config_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            preexec_fn=os.setsid,
+        )
+
+        try:
+            ready = wait_for_port(DEFAULT_HOST, port)
+            if not ready:
+                stdout, stderr = proc.communicate(timeout=1)
+                pytest.fail(
+                    "Server did not listen on the port.\n"
+                    f"stdout:\n{stdout}\n"
+                    f"stderr:\n{stderr}\n"
+                )
+
+            resp_a = requests.get(
+                f"http://{DEFAULT_HOST}:{port}/",
+                headers={"Host": "alpha.example"},
+                timeout=2,
+            )
+            resp_b = requests.get(
+                f"http://{DEFAULT_HOST}:{port}/",
+                headers={"Host": "beta.example"},
+                timeout=2,
+            )
+
+            assert resp_a.status_code == 200
+            assert resp_b.status_code == 200
+            assert host_a_contents in resp_a.text
+            assert host_b_contents in resp_b.text
+            assert resp_a.text != resp_b.text
+        finally:
+            if proc.poll() is None:
+                try:
+                    parent = psutil.Process(proc.pid)
+                    for child in parent.children(recursive=True):
+                        child.kill()
+                    parent.kill()
+                except Exception:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()


### PR DESCRIPTION
### **User description**
### 概要

* `listen.host` を導入して、同一 IP/Port 上で Host 名に応じて VirtualHost を切り替えられるようにしました。
* `VHostResolver` を追加し、`Host` ヘッダと `ListenKey` を使って vhost を決定するルーティングを実装しました。
* `validateListenCompatibility` を拡張し、「(interface, port, host) の組合せ重複のみ禁止」「Host が異なれば同一 IP/Port を共有可」という制約に変更しました。
* リクエストヘッダサイズ制限のチェックを `RequestLimitsMiddleware` に集約し、vhost 決定後の設定に基づいて検証するようにしました。
* デフォルト設定 (`config/default.yaml`) とテストスイートを更新し、Host ベース vhost の起動・ルーティングが保証されるようにしました。

---

### 変更内容

#### 1. `listen.host` の導入と Config パース

* `Config.hpp`

  ```cpp
  struct Listen {
      std::string host;
      std::string interface;
      int port;
  };
  ```

* `ConfigParser.cpp`

  * `createValidListenKeys()` に `"host"` を追加し、`listen` ブロックで許可されるキーを `host/interface/port` に限定。

  * `parseListens()` で `VALID_LISTEN_KEYS` を使うようにし、ローカルな `validKeys` セットを削除。

  * `listen.host` をオプショナルにパースし、未指定時は空文字列とする実装を追加。

    ```cpp
    const Node *hostNode = l_node->getMapNode("host");
    if (!hostNode) {
        l.host = "";
    } else {
        l.host = hostNode->getValue();
    }
    ```

  * `getaddrinfo()` 呼び出しはロジックはそのままに整形のみ変更。

  * `allowedMethods` のバリデーションで、ローカルの `validMethods` ではなく `VALID_ALLOWED_METHODS` を利用するように統一。

    ```cpp
    if (VALID_ALLOWED_METHODS.find(method) == VALID_ALLOWED_METHODS.end()) {
        throw std::runtime_error("Config error: invalid HTTP method '" +
                                 method + "' in server block");
    }
    ```

#### 2. Host ベース VirtualHost 解決 (`VHostResolver`)

* `VHostResolver.hpp / .cpp` を新規追加。

* 比較用ホスト名抽出ヘルパ (`extractHostForMatch`) を定義:

  * 前後の空白を `StringOps::trim` で除去。
  * 最終的に `trim` & `toLower` した値を比較用として返却。

* `VHostResolver::find(...)`:

  ```cpp
  VirtualHost *VHostResolver::find(std::vector<VirtualHost> &vhosts,
                                   const ListenKey &listenKey,
                                   const std::string &hostHeader)
  ```

  * `ListenKey(interface, port)` と一致する `listen` を持つ vhost 群を走査。
  * 最初にマッチした vhost をその (interface, port) の「デフォルト vhost」として保持。
  * Host ヘッダが非空の場合は、各 `listen.host` を `extractHostForMatch` で正規化し、Host ヘッダ側と一致した vhost を優先して返す。
  * Host ヘッダが空、または一致する host がない場合は、その IP/Port に対応するデフォルト vhost を返す。
  * 指定された `ListenKey` にマッチする `listen` が全くない場合は `NULL`。

これにより、「同じ IP/Port でも host 名により vhost を切り替え、Host ヘッダがない／不一致な場合はデフォルト vhost を利用」という動作になります。

#### 3. `Client` が `ListenKey` を保持するように変更

* `Client.hpp / .cpp`

  * コンストラクタシグネチャを `listenPort(int)` から `const ListenKey&` に変更。

    ```cpp
    Client(int fd, const sockaddr_in &addr, const ListenKey &listenKey,
           VirtualHost &activeVhost, size_t maxHeaderBytes,
           Server &server, EventManager &eventManager);
    ```

  * メンバも `int _listenPort` → `ListenKey _listenKey` に変更し、getter を以下のように変更:

    ```cpp
    const ListenKey &Client::getListenKey() const { return _listenKey; }
    ```

* `Server.cpp`

  * `handleNewConnection()` 内での `Client` 生成時に、`accepted.key.port` ではなく `accepted.key` を渡すよう変更。

    ```cpp
    client = new Client(accepted.fd, accepted.addr, accepted.key, *vhost,
                        maxHeaderBytes, *this, _eventManager);
    ```

  * `Server` に vhost 配列へのアクセサを追加し、`VHostSelectMiddleware` から vhosts 全体を参照できるようにした。

    ```cpp
    std::vector<VirtualHost> &getVhosts();
    const std::vector<VirtualHost> &getVhosts() const;
    ```

#### 4. VHostSelectMiddleware による Host ベース vhost 切り替え

* `VHostSelectMiddleware.cpp`

  * `Server` と `VHostResolver` をインクルード。

  * これまで TODO だった Host ヘッダによる選択ロジックを実装:

    ```cpp
    const std::string hostHeader = ctx.req.getHeader("Host");
    VirtualHost *selected = VHostResolver::find(
        ctx.ownerClient.getServer().getVhosts(),
        ctx.ownerClient.getListenKey(), hostHeader);
    ```

  * `selected != NULL` の場合:

    * 現在の `Client` の activeConfig と異なる場合のみ、vhost を切り替えた上でメインパイプラインを再実行。

      ```cpp
      const Config &activeConfig = ctx.ownerClient.getConfig();
      if (&activeConfig != &selected->config) {
          ctx.ownerClient.setActiveVhost(*selected);
          ctx.setConfig(selected->config);
          if (proc) {
              ctx.ownerClient.getMainProcessor().handle(ctx);
          }
          return;
      }
      ```

    * 同一 config の場合は単に `ctx.setConfig(selected->config);` のみに留める。

  * `selected == NULL` の場合は従来どおり `ownerClient.getConfig()` を使用。

  * 以前このミドルウェア内で行っていたヘッダサイズのチェックは削除し、後述の `RequestLimitsMiddleware` に責務を移譲。

#### 5. listen 定義の互換性チェックの拡張

* `ServerBootstrap.cpp`

  * `StringOps` をインクルードし、`normalizeListenHost()` を追加:

    ```cpp
    std::string normalizeListenHost(const std::string &host) {
        std::string normalized = StringOps::trim(host);
        StringOps::toLower(normalized);
        return normalized;
    }
    ```

  * `validateListenCompatibility()` を、`std::set<pair<string,int>> seen` ベースから以下の構造に変更:

    ```cpp
    std::map<std::pair<std::string, int>, std::set<std::string> > hostsByListen;
    ```

  * 各 `Listen` について:

    * `(interface, port)` を key とし、その下に正規化された `host` の集合 `seenHosts` を持つ。

    * 同じ `(interface, port, host)`（正規化後）が二度定義された場合はエラー:

      ```cpp
      if (seenHosts.count(hostKey)) {
          throw std::runtime_error(
              "Config error: duplicate listen host " + listenToString(listen));
      }
      seenHosts.insert(hostKey);
      ```

    * 既存の `0.0.0.0` と特定 IP の混在チェック（wildcardPorts / specificPorts）ロジックは維持。

  * 結果として:

    * 同じ interface/port でも host が異なれば複数 server で共有可能。
    * host 未指定（空文字）の場合は「デフォルト host」として扱われ、空文字同士は重複として禁止。

#### 6. リクエストヘッダサイズ制限の責務整理

* `RequestLimitsMiddleware.cpp`

  * `const Config &config` → `const Config &c` に整理した上で、ヘッダサイズチェックを追加:

    ```cpp
    const size_t headerBytes = ctx.parser.getLastHeaderBytes();
    if (c.getMaxRequestHeaderSize() < headerBytes) {
        ctx.setError(HttpStatus::REQUEST_HEADER_FIELDS_TOO_LARGE);
        if (proc) {
            ErrorHandlerMiddleware errorHandler;
            errorHandler.handle(ctx, proc);
        }
        return;
    }
    ```

  * ボディサイズ制限は、従来通り server レベルの `maxRequestBodySize` をベースにしつつ、`Location` の `hasMaxRequestBodySize` による上書きを適用する形を維持。

* `VHostSelectMiddleware.cpp`

  * これまでここで行っていたヘッダサイズ検証（`ctx.conf->getMaxRequestHeaderSize()` との比較）を削除し、「vhost が決まった後に RequestLimitsMiddleware で一括検証」という構造に統一。

#### 7. デフォルト設定とテストの更新

* `config/default.yaml`

  * 最初の server の listen ポートを `8081` → `8080` に変更。
  * 2つ目の server に `host: localhost` を追加し、`interface` を `0.0.0.0` から `127.0.0.1` に変更。
  * デフォルト設定の段階で「同一 IP/Port (127.0.0.1:8080) を Host ベースで分割する」構成の例として機能するようにした。

* 新規 invalid config:

  * `test/confs/invalid/server/listens/invalid_duplicate_listen_host.yaml`

    * 同じ `interface: 127.0.0.1`, `port: 8080`, `host: example.com` の server を 2 つ定義し、重複検出が働くことを検証する設定。

* 起動テスト (`test_valid_startup.py`)

  * `test_listen_host_allows_same_ip_port` を追加。

    * 同じ `DEFAULT_HOST` + 同一ポートに対して `host: alpha.example` / `host: beta.example` を設定。
    * それぞれ別のドキュメントルートに `index.html` を配置し、Host ヘッダに応じて 200 が返り、コンテンツが異なることを検証。

* ルーティングテスト (`test_ip_port_routing.py`)

  * `test_host_virtualhost_routing_same_ip_port` を追加。

    * 同様に同一 IP/Port 上で `alpha.example` / `beta.example` の 2 vhost を定義。
    * `Host` ヘッダごとに別コンテンツが返ること、かつレスポンス内容が異なることを検証。

---

### 互換性・影響範囲

* `listen.host` はオプションであり、既存の設定ファイルに host を追加しなくても、従来通り IP/Port ベースの vhost 振り分けが動作します。
* 同一 (interface, port) に対して複数 server を定義している場合、これまでは即エラーだったケースでも、`host` を分けることで共存可能になります。
* 一方で、「完全に同一の (interface, port, host) を複数 server に定義する」設定は新たにエラーとなります（Host ベース vhost の一意性を担保するため）。
* リクエストヘッダサイズ制限のチェック位置が `VHostSelectMiddleware` から `RequestLimitsMiddleware` に移動していますが、「vhost 決定後の設定を使って制限をかける」という挙動自体は維持されます。

---

### 動作確認観点（想定）

この PR により、以下の観点での挙動確認が可能／必要になります。

* 同一 IP/Port（例: `127.0.0.1:8080`）に対して `host` を変えた複数 vhost を定義した場合に、Host ヘッダに応じて正しくルーティングされること。
* Host ヘッダが省略・空の場合に、対応する listen のデフォルト vhost が利用されること。
* `invalid_duplicate_listen_host.yaml` を使った起動で、重複 listen host エラーが期待通り発生すること。
* 既存の IP/Port ベース vhost ルーティングや単一 vhost 構成が、今回の変更によって壊れていないこと（後方互換性）。


___

### **PR Type**
Enhancement


___

### **Description**
- Added `listen.host` field to enable name-based virtual host routing on same IP/Port

- Implemented `VHostResolver` to select vhost based on Host header and listen configuration

- Updated `validateListenCompatibility` to allow duplicate IP/Port with different host names

- Moved request header size validation from `VHostSelectMiddleware` to `RequestLimitsMiddleware`

- Added comprehensive tests for host-based virtual host routing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config with listen.host"] -->|Parse| B["Listen struct updated"]
  B -->|Validate| C["validateListenCompatibility"]
  C -->|Allow same IP:Port| D["Different host names"]
  E["HTTP Request"] -->|Extract Host header| F["VHostSelectMiddleware"]
  F -->|Resolve vhost| G["VHostResolver"]
  G -->|Match listen.host| H["Select VirtualHost"]
  H -->|Set config| I["RequestLimitsMiddleware"]
  I -->|Validate header size| J["Process request"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>Config.hpp</strong><dd><code>Added host field to Listen struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-cbb49d77c7de6670d89cc836a844917273782b5abaaf9a0498cc6ee05d289cc7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ConfigParser.cpp</strong><dd><code>Parse listen.host and validate listen keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-700a47fc6e6ecf0786bf039675bb4b733a684be5249908205e3eac8bedeaa8a5">+12/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>VHostResolver.hpp</strong><dd><code>New VHostResolver class for host-based routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-2a66ea10351fd43aa8e92930c670fd768daffab02efde646ec186c003a6a5142">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>VHostResolver.cpp</strong><dd><code>Implement vhost selection logic with host matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-b124af05f4003c06bfa71438862bc238e052d244b5c6faffdd2f18ab58f47538">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>VHostSelectMiddleware.cpp</strong><dd><code>Integrate VHostResolver for Host header-based selection</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-b929032bc484027a5dcea9be3e681ee5efe77044efeb01c7d7111c67c95d8daf">+20/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RequestLimitsMiddleware.cpp</strong><dd><code>Add request header size validation to middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-35685b85fc4459a62f3025bdb3a86040e3a65da1d428b17561704af40ee49401">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ServerBootstrap.cpp</strong><dd><code>Update listen validation for host-based duplicates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-58c816e8e7c271ca51e574b24217e0fab7e4857479a3386b668260119ee30c2c">+16/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Client.hpp</strong><dd><code>Replace listenPort with ListenKey struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-d30ede87352d8b992a5099aff1f681b148e79442238d4d04da60dab8e65e30c2">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Client.cpp</strong><dd><code>Update Client constructor to use ListenKey</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-f800287b65aac006ab1cc1ce90698fe67ea7650d2c1543412ab70ea08802735a">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Server.hpp</strong><dd><code>Add getVhosts accessor methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-502d81d654329e071d5e7208aa34c844f6c1f4cd1450f630a50ac43406a85b47">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Server.cpp</strong><dd><code>Implement getVhosts and update Client creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-fb41303897ea5ab11fcca3cca1f38a4422dc8ce9799ec81dac00ff11a7a1370b">+15/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>default.yaml</strong><dd><code>Update default config with listen.host example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-a539f2e066889598fd148cd5d815d0bfd6e8c472bf4474a91c441f08c8c3a31b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_valid_startup.py</strong><dd><code>Add test for host-based listen on same IP/Port</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-c34b9774bd060ac91c79bbaed19d4df203c5563cfd948b5cfe32c6c10f33b549">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ip_port_routing.py</strong><dd><code>Add integration test for host-based vhost routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-001e04da4d4a955079b58013f922e5216749d5f84626f99ef2550fef0a631607">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>invalid_duplicate_listen_host.yaml</strong><dd><code>Add config test for duplicate listen host validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TetsuroAndo/42-webserv/pull/313/files#diff-1b62819824072b8b25c0fae6ced79fd0e401b40b291a4054637cf7e36499de24">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Hostヘッダーに基づく仮想ホスト解決で、同一IP/同一ポート上の複数ホストを振り分けます。
  * listen設定でホスト指定が可能になり、ホスト単位での重複検出が行われます。

* **変更**
  * デフォルト待ち受けポートを8081から8080に変更しました。
  * 一部リスニング設定が localhost/127.0.0.1 に明示的にバインドされるようになりました。

* **テスト**
  * 同一IP/同一ポートでのホスト別ルーティングを検証する統合テストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->